### PR TITLE
Map app

### DIFF
--- a/public/js/keys.js
+++ b/public/js/keys.js
@@ -1,6 +1,6 @@
 console.log('Keys loaded');
 
 exports.mapbox = {
-  public_key: process.env.PUBLIC_TOKEN
+  accessToken: process.env.PUBLIC_TOKEN
  
 };

--- a/public/js/map.js
+++ b/public/js/map.js
@@ -1,15 +1,27 @@
-var MapboxClient = require("mapbox");
-var importKeys = require('./keys');
-var mapBoxClient = new MapboxClient(importKeys.mapbox);
+  // dependencies
+  var MapboxClient = require("mapbox");
+  // var importKeys = require('./keys');
+  // var mapBoxClient = new MapboxClient(importKeys.mapbox);
 
-// Ex:
-// var client = new MapboxClient("YOUR_ACCESS_TOKEN");
+  var client = new MapboxClient(
+    "pk.eyJ1IjoiaGVucnloYW5rZGMiLCJhIjoiY2plcmF4YXkwMHQxbTJ3bXV2cG9kNjY3NCJ9.nR_dD4v96HlpfLDnjcim-A"
+  );
+  // var to hold user entered location
+  var location = 'Washington, DC';
+  var passedLocation;
 
-mapBoxClient.geocodeForward("Washington, DC")
-  .then(function(res) {
-    // res is the http response, including: status, headers and entity properties
-    var data = res.entity; // data is the geocoding result as parsed JSON
-  })
-  .catch(function(err) {
-    // handle errors
+  client.geocodeForward(location, function(err, data, res) {
+    // data is the geocoding result as parsed JSON
+    // return long/lat based on address
+    passedLocation = data.features[1].geometry.coordinates;
+
+
+    if (err) {
+      return console.log("Error occurred: " + err);
+    }
   });
+
+
+  function createMap() {
+    // map function will live here
+  }


### PR DESCRIPTION
Super minor name changes to keys.js. 

Added public token to map.js. Why? Because apparently it's totally fine to do that with the public key according to mapbox. They have a thing built into their api that lets you easily regenerate it if you think it's being abused. We move it back to the .env file later, but for now I'm leaving it in map.js to make my life easier. 

Set up initial path for grabbing lat/long from user submitted location.

